### PR TITLE
Allow build with systems libenet, but still support own version.

### DIFF
--- a/source/src/Makefile
+++ b/source/src/Makefile
@@ -1,5 +1,18 @@
 DEBUG ?= 0
 WARNINGS ?= 1
+
+PKGCONFIG  ?= pkg-config
+HAS_PKGCFG := $(shell which $(PKGCONFIG) 2>&1 >/dev/null && echo yes || echo no)
+
+HAS_ENET := no
+ifeq ($(HAS_PKGCFG),yes)
+    HAS_ENET := $(shell $(PKGCONFIG) libenet && echo yes || echo no)
+    ifeq ($(HAS_ENET),yes)
+        ENET_CF := $(CXXFLAGS) $(shell $(PKGCONFIG) --cflags libenet)
+        ENET_LF := $(LDFLAGS) $(shell $(PKGCONFIG) --libs libenet)
+    endif
+endif
+
 override CXXFLAGS += -fsigned-char
 ifeq ($(DEBUG), 1)
     override CXXFLAGS += -ggdb3 -D_DEBUG -Wextra
@@ -27,7 +40,11 @@ endif
 PLATFORM= $(shell uname -s)
 PLATFORM_PREFIX=native
 
-INCLUDES= -I. -Ibot -I../enet/include
+ifeq ($(HAS_ENET),yes)
+    INCLUDES := -I. -Ibot $(ENET_CF)
+else
+    INCLUDES := -I. -Ibot -I../enet/include
+endif
 
 STRIP=
 ifeq (,$(findstring -g,$(CXXFLAGS)))
@@ -45,7 +62,12 @@ else
 USRLIB=$(shell if [ -e /usr/lib64 ]; then echo "/usr/lib64"; else echo "/usr/lib"; fi)
 #override CXXFLAGS+= -rdynamic  # clang++ doesn't use this...
 CLIENT_INCLUDES= $(INCLUDES) -I/usr/include `sdl-config --cflags` -idirafter ../include
-CLIENT_LIBS= -L../enet/.libs -lenet -L$(USRLIB) -lX11 `sdl-config --libs` -lSDL_image -lz -lGL -lopenal -lvorbisfile -lcurl
+ifeq ($(HAS_ENET),yes)
+	CLIENT_LIBS := $(ENET_LF)
+else
+	CLIENT_LIBS := -L../enet/.libs -lenet
+endif
+CLIENT_LIBS := $(CLIENT_LIBS) -L$(USRLIB) -lX11 `sdl-config --libs` -lSDL_image -lz -lGL -lopenal -lvorbisfile -lcurl
 endif
 
 CLIENT_OBJS= \
@@ -106,11 +128,16 @@ CLIENT_OBJS= \
 CLIENT_PCH= cube.h.gch
 
 ifneq (,$(findstring MINGW,$(PLATFORM)))
-SERVER_INCLUDES= -DSTANDALONE $(INCLUDES) -I../include
-SERVER_LIBS= -L../lib -lzdll -lenet -llibintl -lws2_32 -lwinmm
+	SERVER_INCLUDES= -DSTANDALONE $(INCLUDES) -I../include
+	SERVER_LIBS= -L../lib -lzdll -lenet -llibintl -lws2_32 -lwinmm
 else
-SERVER_INCLUDES= -DSTANDALONE $(INCLUDES)
-SERVER_LIBS= -L../enet/.libs -lenet -lz
+	SERVER_INCLUDES= -DSTANDALONE $(INCLUDES)
+	ifeq ($(HAS_ENET),yes)
+		SERVER_LIBS := $(ENET_LF)
+	else
+		SERVER_LIBS := -L../enet/.libs -lenet
+	endif
+	SERVER_LIBS := $(SERVER_LIBS) -lz
 endif
 
 SERVER_OBJS= \
@@ -137,6 +164,7 @@ default: all
 
 all: client server
 
+ifneq ($(HAS_ENET),yes)
 ../enet/Makefile:
 	cd ../enet; ./configure --enable-shared=no --enable-static=yes
 
@@ -145,6 +173,7 @@ libenet: ../enet/Makefile
 
 clean-enet: ../enet/Makefile
 	$(MAKE) -C ../enet/ clean
+endif
 
 clean:
 	-$(RM) $(CLIENT_PCH) $(CLIENT_OBJS) $(SERVER_OBJS) $(MASTER_OBJS) ac_client ac_server ac_master
@@ -177,12 +206,16 @@ client_install: client
 server_install: server
 
 else
-client: libenet $(CLIENT_OBJS)
+ifeq ($(HAS_ENET),no)
+ENET_TARGET := libenet
+endif
+
+client: $(ENET_TARGET) $(CLIENT_OBJS)
 	$(CXX) $(CXXFLAGS) -o ac_client $(CLIENT_OBJS) $(CLIENT_LIBS)
 
-server: libenet $(SERVER_OBJS)
+server: $(ENET_TARGET) $(SERVER_OBJS)
 	$(CXX) $(CXXFLAGS) -o ac_server $(SERVER_OBJS) $(SERVER_LIBS)
-master: libenet $(MASTER_OBJS)
+master: $(ENET_TARGET) $(MASTER_OBJS)
 	$(CXX) $(CXXFLAGS) -o ac_master $(MASTER_OBJS) $(SERVER_LIBS)
 
 client_install: client


### PR DESCRIPTION
This will not completely unbundle enet like https://github.com/acreloaded/acr/pull/12
But will support build with a enet version provided by the system.

So like said in https://github.com/acreloaded/acr/pull/195 some Linux distributions do not provide enet, that distros would then use the bundled one.
But other can use their system one.

Tested it with current release and enet7 (1.3.13) works :-)
