### PR TITLE
fixed ugly font bug when resetting OpenGL

### DIFF
--- a/source/src/main.cpp
+++ b/source/src/main.cpp
@@ -656,11 +656,11 @@ void resetgl()
     if(!reloadtexture(*notexture) ||
        !reloadtexture("packages/misc/startscreen.png"))
         fatal("failed to reload core texture");
+    reloadfonts();
     loadingscreen(_("resetting OpenGL (2/2)"));
     c2skeepalive();
     restoregamma();
     c2skeepalive();
-    reloadfonts();
     reloadtextures();
     c2skeepalive();
     drawscope(true); // 2011feb05:ft: preload scope.png


### PR DESCRIPTION
hello, guys. please, review this fix and consider to include in your repo.
thanks.
basically, it happens when you change video settings. white squares on loading screen appear instead of text.